### PR TITLE
Fix dynamic manifest processing

### DIFF
--- a/ndash/src/chunk/chunk_extractor_wrapper.h
+++ b/ndash/src/chunk/chunk_extractor_wrapper.h
@@ -45,12 +45,12 @@ class SingleTrackOutputInterface;
 // The wrapper allows switching of the SingleTrackOutput that receives parsed
 // data.
 class ChunkExtractorWrapper : public extractor::ExtractorOutputInterface,
-                              public extractor::TrackOutputInterface {
+                              public extractor::TrackOutputInterface,
+                              public base::RefCounted<ChunkExtractorWrapper> {
  public:
   // extractor: The Extractor to wrap.
   explicit ChunkExtractorWrapper(
       std::unique_ptr<extractor::ExtractorInterface> extractor);
-  ~ChunkExtractorWrapper() override;
 
   // Initializes the extractor to output to the provided
   // SingleTrackOutputInterface, and configures it to receive data from a new
@@ -100,6 +100,9 @@ class ChunkExtractorWrapper : public extractor::ExtractorOutputInterface,
                            std::vector<int32_t>* num_bytes_enc) override;
 
  private:
+  ~ChunkExtractorWrapper() override;
+
+  friend class base::RefCounted<ChunkExtractorWrapper>;
   std::unique_ptr<extractor::ExtractorInterface> extractor_;
   bool extractor_initialized_ = false;
   SingleTrackOutputInterface* output_ = nullptr;

--- a/ndash/src/chunk/container_media_chunk.h
+++ b/ndash/src/chunk/container_media_chunk.h
@@ -89,8 +89,8 @@ class ContainerMediaChunk : public BaseMediaChunk,
       int64_t end_time_us,
       int32_t chunk_index,
       base::TimeDelta sample_offset,
-      ChunkExtractorWrapper* extractor_wrapper,
-      const MediaFormat* media_format,
+      scoped_refptr<ChunkExtractorWrapper> extractor_wrapper,
+      std::unique_ptr<const MediaFormat> media_format,
       scoped_refptr<const drm::RefCountedDrmInitData> drm_init_data,
       bool is_media_format_final,
       int parent_id);
@@ -139,7 +139,7 @@ class ContainerMediaChunk : public BaseMediaChunk,
  private:
   // Only accessed by loader thread, so no locking required
   upstream::DataSourceInterface* data_source_;
-  ChunkExtractorWrapper* extractor_wrapper_;
+  scoped_refptr<ChunkExtractorWrapper> extractor_wrapper_;
 
   // No locking required with these because they're const
   const base::TimeDelta sample_offset_;
@@ -153,8 +153,8 @@ class ContainerMediaChunk : public BaseMediaChunk,
   int64_t bytes_loaded_ = 0;
   base::CancellationFlag load_canceled_;
 
-  static std::unique_ptr<MediaFormat> GetAdjustedMediaFormat(
-      const MediaFormat* format,
+  static std::unique_ptr<const MediaFormat> GetAdjustedMediaFormat(
+      std::unique_ptr<const MediaFormat>,
       base::TimeDelta sample_offset);
 };
 

--- a/ndash/src/chunk/initialization_chunk.cc
+++ b/ndash/src/chunk/initialization_chunk.cc
@@ -36,7 +36,7 @@ InitializationChunk::InitializationChunk(
     const upstream::DataSpec* data_spec,
     TriggerReason trigger,
     const util::Format* format,
-    ChunkExtractorWrapper* extractor_wrapper,
+    scoped_refptr<ChunkExtractorWrapper> extractor_wrapper,
     int parent_id)
     : Chunk(data_spec, kTypeMediaInitialization, trigger, format, parent_id),
       data_source_(data_source),

--- a/ndash/src/chunk/initialization_chunk.h
+++ b/ndash/src/chunk/initialization_chunk.h
@@ -67,7 +67,7 @@ class InitializationChunk : public Chunk, public SingleTrackOutputInterface {
                       const upstream::DataSpec* data_spec,
                       TriggerReason trigger,
                       const util::Format* format,
-                      ChunkExtractorWrapper* extractor_wrapper,
+                      scoped_refptr<ChunkExtractorWrapper> extractor_wrapper,
                       int parent_id = kNoParentId);
   ~InitializationChunk() override;
 
@@ -142,7 +142,7 @@ class InitializationChunk : public Chunk, public SingleTrackOutputInterface {
  private:
   // Only accessed by loader thread, so no locking required
   upstream::DataSourceInterface* data_source_;
-  ChunkExtractorWrapper* extractor_wrapper_;
+  scoped_refptr<ChunkExtractorWrapper> extractor_wrapper_;
 
   // Initialization results. Set by the loader thread and read by any thread
   // that knows loading has completed. These variables do not need a lock,

--- a/ndash/src/chunk/initialization_chunk_unittest.cc
+++ b/ndash/src/chunk/initialization_chunk_unittest.cc
@@ -27,10 +27,10 @@
 namespace ndash {
 namespace chunk {
 
-using ::testing::_;
 using ::testing::Eq;
 using ::testing::IsNull;
 using ::testing::Return;
+using ::testing::_;
 
 TEST(InitializationChunkTest, CanInstantiateMock) {
   upstream::Uri dummy_uri("dummy://");
@@ -101,14 +101,15 @@ TEST(InitializationChunkTest, TestLoad) {
   extractor::MockExtractor* mock_extractor =
       static_cast<extractor::MockExtractor*>(extractor_interface.get());
 
-  ChunkExtractorWrapper wrapper(std::move(extractor_interface));
+  scoped_refptr<ChunkExtractorWrapper> wrapper(
+      new ChunkExtractorWrapper(std::move(extractor_interface)));
 
   InitializationChunk init_chunk(&data_source, &data_spec,
-                                 Chunk::kTriggerUnspecified, nullptr, &wrapper,
+                                 Chunk::kTriggerUnspecified, nullptr, wrapper,
                                  Chunk::kNoParentId);
 
   EXPECT_CALL(data_source, Open(_, _)).WillOnce(Return(0));
-  EXPECT_CALL(*mock_extractor, Init(&wrapper)).WillOnce(Return());
+  EXPECT_CALL(*mock_extractor, Init(wrapper.get())).WillOnce(Return());
   EXPECT_CALL(data_source, Close()).WillOnce(Return());
 
   EXPECT_CALL(*mock_extractor, Read(_, _))

--- a/ndash/src/chunk/single_sample_media_chunk.cc
+++ b/ndash/src/chunk/single_sample_media_chunk.cc
@@ -39,7 +39,7 @@ SingleSampleMediaChunk::SingleSampleMediaChunk(
     int64_t start_time_us,
     int64_t end_time_us,
     int32_t chunk_index,
-    const MediaFormat* sample_format,
+    std::unique_ptr<const MediaFormat> sample_format,
     scoped_refptr<const drm::RefCountedDrmInitData> sample_drm_init_data,
     int parent_id)
     : BaseMediaChunk(data_spec,
@@ -51,13 +51,13 @@ SingleSampleMediaChunk::SingleSampleMediaChunk(
                      true,
                      parent_id),
       data_source_(data_source),
-      sample_format_(sample_format),
+      sample_format_(std::move(sample_format)),
       sample_drm_init_data_(std::move(sample_drm_init_data)) {}
 
 SingleSampleMediaChunk::~SingleSampleMediaChunk() {}
 
 const MediaFormat* SingleSampleMediaChunk::GetMediaFormat() const {
-  return sample_format_;
+  return sample_format_.get();
 }
 
 scoped_refptr<const drm::RefCountedDrmInitData>

--- a/ndash/src/chunk/single_sample_media_chunk.h
+++ b/ndash/src/chunk/single_sample_media_chunk.h
@@ -68,7 +68,7 @@ class SingleSampleMediaChunk : public BaseMediaChunk {
       int64_t start_time_us,
       int64_t end_time_us,
       int32_t chunk_index,
-      const MediaFormat* sample_format,
+      std::unique_ptr<const MediaFormat> sample_format,
       scoped_refptr<const drm::RefCountedDrmInitData> sample_drm_init_data,
       int parent_id);
   ~SingleSampleMediaChunk() override;
@@ -88,7 +88,7 @@ class SingleSampleMediaChunk : public BaseMediaChunk {
 
  private:
   upstream::DataSourceInterface* data_source_;
-  const MediaFormat* sample_format_;
+  std::unique_ptr<const MediaFormat> sample_format_;
   scoped_refptr<const drm::RefCountedDrmInitData> sample_drm_init_data_;
 
   mutable base::Lock lock_;

--- a/ndash/src/chunk/single_sample_media_chunk_unittest.cc
+++ b/ndash/src/chunk/single_sample_media_chunk_unittest.cc
@@ -69,12 +69,13 @@ TEST(SingleSampleMediaChunkTest, Accessors) {
   util::Format format("", "", 0, 0, 0.0, 1, 0, 0, 0);
   std::unique_ptr<MediaFormat> sample_format =
       MediaFormat::CreateTextFormat("track", "text/plain", 100, 5000);
+  MediaFormat* sample_format_ptr = sample_format.get();
   drm::MockDrmInitData* drm_init_data = new drm::MockDrmInitData;
   scoped_refptr<drm::RefCountedDrmInitData> drm_init_data_ref(drm_init_data);
 
   SingleSampleMediaChunk ss_chunk(
       &data_source, &data_spec, Chunk::kTriggerUnspecified, &format, kStartTime,
-      kEndTime, kChunkIndex, sample_format.get(), drm_init_data_ref,
+      kEndTime, kChunkIndex, std::move(sample_format), drm_init_data_ref,
       Chunk::kNoParentId);
 
   EXPECT_THAT(*ss_chunk.data_spec(),
@@ -83,7 +84,7 @@ TEST(SingleSampleMediaChunkTest, Accessors) {
   EXPECT_THAT(ss_chunk.start_time_us(), Eq(kStartTime));
   EXPECT_THAT(ss_chunk.end_time_us(), Eq(kEndTime));
   EXPECT_THAT(ss_chunk.chunk_index(), Eq(kChunkIndex));
-  EXPECT_THAT(ss_chunk.GetMediaFormat(), Eq(sample_format.get()));
+  EXPECT_THAT(ss_chunk.GetMediaFormat(), Eq(sample_format_ptr));
   EXPECT_THAT(ss_chunk.GetDrmInitData(), Eq(drm_init_data_ref));
   EXPECT_THAT(ss_chunk.parent_id(), Eq(Chunk::kNoParentId));
   EXPECT_THAT(ss_chunk.GetNumBytesLoaded(), Eq(0));
@@ -102,7 +103,7 @@ TEST(SingleSampleMediaChunkTest, TestLoadSuccess) {
 
   SingleSampleMediaChunk ss_chunk(
       &data_source, &data_spec, Chunk::kTriggerUnspecified, &format, kStartTime,
-      kEndTime, kChunkIndex, sample_format.get(), drm_init_data_ref,
+      kEndTime, kChunkIndex, std::move(sample_format), drm_init_data_ref,
       Chunk::kNoParentId);
 
   extractor::MockIndexedTrackOutput mock_output;
@@ -156,7 +157,7 @@ TEST(SingleSampleMediaChunkTest, TestLoadFail) {
 
   SingleSampleMediaChunk ss_chunk(
       &data_source, &data_spec, Chunk::kTriggerUnspecified, &format, kStartTime,
-      kEndTime, kChunkIndex, sample_format.get(), drm_init_data_ref,
+      kEndTime, kChunkIndex, std::move(sample_format), drm_init_data_ref,
       Chunk::kNoParentId);
 
   extractor::MockIndexedTrackOutput mock_output;
@@ -201,7 +202,7 @@ TEST(SingleSampleMediaChunkTest, TestLoadCancel) {
 
   SingleSampleMediaChunk ss_chunk(
       &data_source, &data_spec, Chunk::kTriggerUnspecified, &format, kStartTime,
-      kEndTime, kChunkIndex, sample_format.get(), drm_init_data_ref,
+      kEndTime, kChunkIndex, std::move(sample_format), drm_init_data_ref,
       Chunk::kNoParentId);
 
   extractor::MockIndexedTrackOutput mock_output;

--- a/ndash/src/dash/dash_chunk_source.h
+++ b/ndash/src/dash/dash_chunk_source.h
@@ -178,27 +178,29 @@ class DashChunkSource : public chunk::ChunkSourceInterface {
   friend class DashChunkSourceTest;
 
   // For TESTING
-  DashChunkSource(drm::DrmSessionManagerInterface* drm_session_manager,
-                  const mpd::MediaPresentationDescription* manifest,
-                  upstream::DataSourceInterface* data_source,
-                  chunk::FormatEvaluatorInterface* adaptive_format_evaluator,
-                  const mpd::AdaptationType& adaptation_type,
-                  const PlaybackRate* playback_rate,
-                  qoe::QoeManager* qoe = nullptr);
+  DashChunkSource(
+      drm::DrmSessionManagerInterface* drm_session_manager,
+      scoped_refptr<const mpd::MediaPresentationDescription> manifest,
+      upstream::DataSourceInterface* data_source,
+      chunk::FormatEvaluatorInterface* adaptive_format_evaluator,
+      const mpd::AdaptationType& adaptation_type,
+      const PlaybackRate* playback_rate,
+      qoe::QoeManager* qoe = nullptr);
 
-  DashChunkSource(drm::DrmSessionManagerInterface* drm_session_manager,
-                  ManifestFetcher* manifest_fetcher,
-                  const mpd::MediaPresentationDescription* initial_manifest,
-                  upstream::DataSourceInterface* data_source,
-                  chunk::FormatEvaluatorInterface* adaptive_format_evaluator,
-                  const mpd::AdaptationType& adaptation_type,
-                  std::unique_ptr<base::TickClock> clock,
-                  base::TimeDelta live_edge_latency,
-                  base::TimeDelta elapsed_realtime_offset,
-                  bool start_at_live_edge,
-                  AvailableRangeChangedCB range_changed_cb,
-                  const PlaybackRate* playback_rate,
-                  qoe::QoeManager* qoe = nullptr);
+  DashChunkSource(
+      drm::DrmSessionManagerInterface* drm_session_manager,
+      ManifestFetcher* manifest_fetcher,
+      scoped_refptr<const mpd::MediaPresentationDescription> initial_manifest,
+      upstream::DataSourceInterface* data_source,
+      chunk::FormatEvaluatorInterface* adaptive_format_evaluator,
+      const mpd::AdaptationType& adaptation_type,
+      std::unique_ptr<base::TickClock> clock,
+      base::TimeDelta live_edge_latency,
+      base::TimeDelta elapsed_realtime_offset,
+      bool start_at_live_edge,
+      AvailableRangeChangedCB range_changed_cb,
+      const PlaybackRate* playback_rate,
+      qoe::QoeManager* qoe = nullptr);
 
   static std::unique_ptr<MediaFormat> GetTrackFormat(
       mpd::AdaptationType adaptation_set_type,
@@ -214,7 +216,7 @@ class DashChunkSource : public chunk::ChunkSourceInterface {
       const mpd::RangedUri* initialization_uri,
       const mpd::RangedUri* index_uri,
       const mpd::Representation& representation,
-      chunk::ChunkExtractorWrapper* extractor,
+      scoped_refptr<chunk::ChunkExtractorWrapper> extractor,
       upstream::DataSourceInterface* data_source,
       int32_t manifest_index,
       chunk::Chunk::TriggerReason trigger,
@@ -224,7 +226,7 @@ class DashChunkSource : public chunk::ChunkSourceInterface {
       const PeriodHolder& period_holder,
       RepresentationHolder* representation_holder,
       upstream::DataSourceInterface* data_source,
-      const MediaFormat* media_format,
+      std::unique_ptr<const MediaFormat> media_format,
       int32_t segment_num,
       chunk::Chunk::TriggerReason trigger,
       chunk::Chunk::FormatGivenCB format_given_cb);
@@ -238,7 +240,8 @@ class DashChunkSource : public chunk::ChunkSourceInterface {
   PeriodHolder* FindPeriodHolder(base::TimeDelta position);
   const PeriodHolder* FindPeriodHolder(base::TimeDelta position) const;
 
-  void ProcessManifest(const mpd::MediaPresentationDescription* manifest);
+  void ProcessManifest(
+      scoped_refptr<const mpd::MediaPresentationDescription> manifest);
 
   void NotifyAvailableRangeChanged(const TimeRangeInterface& seek_range);
 

--- a/ndash/src/dash/period_holder.h
+++ b/ndash/src/dash/period_holder.h
@@ -123,7 +123,9 @@ class PeriodHolder {
                     int32_t manifest_index,
                     const TrackCriteria* track_criteria);
 
-  // For when any representation will do
+  // For when any representation will do. This pointer is only valid for the
+  // current DashThread task.  It is not safe to store it since DashThread
+  // update may cause it to become invalid before the next tasks's execution.
   const mpd::DashSegmentIndexInterface* GetArbitrarySegmentIndex() const;
 
  private:

--- a/ndash/src/dash_thread.h
+++ b/ndash/src/dash_thread.h
@@ -273,6 +273,8 @@ class DashThread : public base::Thread,
 
   void SetState(PlayerState new_state);
 
+  // NOTE: Caller should copy format if contents are required beyond the scope
+  // of the current executing task.
   void FormatGiven(TrackContext* track, const MediaFormat* format);
 
   void NewBandwidthEstimate(base::TimeDelta elapsed,

--- a/ndash/src/manifest_fetcher.cc
+++ b/ndash/src/manifest_fetcher.cc
@@ -16,12 +16,8 @@
 
 #include "manifest_fetcher.h"
 
-#include <algorithm>
-#include <string>
-
 #include "base/bind.h"
 #include "base/callback_helpers.h"
-#include "base/location.h"
 #include "upstream/constants.h"
 #include "upstream/curl_data_source.h"
 #include "upstream/data_spec.h"
@@ -91,8 +87,9 @@ void ManifestFetcher::UpdateManifestUri(const std::string& manifest_uri) {
   manifest_uri_ = manifest_uri;
 }
 
-const mpd::MediaPresentationDescription* ManifestFetcher::GetManifest() const {
-  return manifest_.get();
+const scoped_refptr<mpd::MediaPresentationDescription>
+ManifestFetcher::GetManifest() const {
+  return manifest_;
 }
 
 base::TimeTicks ManifestFetcher::GetManifestLoadStartTimestamp() const {

--- a/ndash/src/manifest_fetcher.h
+++ b/ndash/src/manifest_fetcher.h
@@ -73,7 +73,7 @@ class ManifestFetcher {
 
   // Get a pointer to the most recent parsed manifest this manifest fetcher
   // is holding. May be null.
-  const mpd::MediaPresentationDescription* GetManifest() const;
+  const scoped_refptr<mpd::MediaPresentationDescription> GetManifest() const;
 
   // Returns true iff a manifest is held
   bool HasManifest() const { return manifest_ != nullptr; }

--- a/ndash/src/manifest_fetcher_unittest.cc
+++ b/ndash/src/manifest_fetcher_unittest.cc
@@ -49,9 +49,9 @@ TEST(ManifestFetcherTests, RequestRefreshTest) {
     }
     void OnManifestRefreshStarted() override { refresh_started_called_ = true; }
     void OnManifestRefreshed() override {
-      const mpd::MediaPresentationDescription* mpd;
-      mpd = fetcher_->GetManifest();
-      if (mpd != nullptr) {
+      const scoped_refptr<mpd::MediaPresentationDescription> mpd =
+          fetcher_->GetManifest();
+      if (mpd.get() != nullptr) {
         EXPECT_TRUE(mpd->GetPeriodCount() > 0);
         EXPECT_TRUE(refresh_started_called_);
         manifest_was_refreshed_ = true;


### PR DESCRIPTION
This CL fixes issue 1: Dynamic manifests (LIVE) causes SEGFAULT
after 1st refresh (https://github.com/google/ndash/issues/1).

NDash was crashing on YouTube manifests if /mpd_version/4 or
mpd_version=4 was omited from the manifest url. This tells youtube to
revert back to v1 behavior which is essentially broken and produces bad
manifests.

In YouTube's v1 manifests, the period's start time increases after every
refresh which causes NDash to think it's a new period each time.  There is
no 'id' on a period so the only thing that uniquely identifies it is its
start time.  (Period's start times are not supposed to change and it
appears YouTube's initial implementation of a live window mistakenly
updates the start time on each refresh.)

This, in turn, caused NDash to remove the previous period from its
period holder list causing objects owned by the period/representation holders
to be destroyed while loaders were still using them. (Most notibly was
the ChunkExtractorWrapper which held the stream parser, media log, etc.)
The representation holder's unique ptr to ChunkExtractorWrapper was changed
to a scoped ref ptr so that other parts of the code can be sure they
will still be alive even if the representation holder happens to get
destroyed.  However, as long as incoming manifests are well behaved,
this should actually never happen.

For additional safety, I also gave the representation holders their own
copy of the media format instead of holding on to pointers from the
manifest which might get destroyed while the holder is still alive.

This CL doesn't really address the underlying issue which is that
pointers to objects owned by the manifest might get passed around to
other parts of the code that expect them to live beyond the life of the
manifest.  Likewise for Period/Representation holders.  This CL plugs the
known holes but others may crop up in the future.

Also discovered a line of code that was missing from the original port
in representation holder where the index should have been updated.