### PR TITLE
Handle resolution changes in the reference player

### DIFF
--- a/examples/sdl_player/src/player.h
+++ b/examples/sdl_player/src/player.h
@@ -54,8 +54,7 @@ class Player {
  private:
   Player(std::unique_ptr<NDashStream> dash_stream,
          WindowPtr window,
-         RendererPtr renderer,
-         TexturePtr texture);
+         RendererPtr renderer);
 
   util::StatusOr<std::unique_ptr<FrameSourceQueue>> CreateFrameQueue();
   void RenderLoop();
@@ -79,6 +78,10 @@ class Player {
   std::thread frame_decoder_thread_;
   int64_t start_time_ms_;
   int playback_rate_index_;
+
+  // Used to detect resolution changes which require a newly sized texture.
+  int prev_frame_width = -1;
+  int prev_frame_height = -1;
 };
 
 }  // namespace player

--- a/ndash/src/chunk/chunk_sample_source.cc
+++ b/ndash/src/chunk/chunk_sample_source.cc
@@ -226,7 +226,7 @@ SampleSourceReaderInterface::ReadResult ChunkSampleSource::ReadData(
     // arrive here.
     const MediaFormat* media_format = current_chunk->GetMediaFormat();
     if (media_format && media_format != downstream_media_format_.get()) {
-      format_holder->format = media_format->AsWeakPtr();
+      format_holder->format.reset(new MediaFormat(*media_format));
       format_holder->drm_init_data = current_chunk->GetDrmInitData();
       downstream_media_format_ = media_format->AsWeakPtr();
       return FORMAT_READ;

--- a/ndash/src/dash_thread.cc
+++ b/ndash/src/dash_thread.cc
@@ -1155,6 +1155,9 @@ int DashThread::CopyFrameImpl(void* buffer,
 
   fi->type = current_track_->frame_type_;
 
+  fi->width = current_track_->format_holder_.format->GetWidth();
+  fi->height = current_track_->format_holder_.format->GetHeight();
+
   int64_t sample_time_us =
       sample_holder->GetTimeUs() - GetSampleOffsetMs() * 1000;
   util::PresentationTime pt = util::PresentationTimeFromUs(sample_time_us);

--- a/ndash/src/media_format_holder.h
+++ b/ndash/src/media_format_holder.h
@@ -32,7 +32,7 @@ namespace ndash {
 // Holds a MediaFormat and corresponding drm scheme initialization data.
 struct MediaFormatHolder {
   // The format of the media.
-  base::WeakPtr<const MediaFormat> format;
+  std::unique_ptr<const MediaFormat> format;
 
   // Initialization data for drm schemes supported by the media. Null if the
   // media is not encrypted.

--- a/ndash/src/ndash.h
+++ b/ndash/src/ndash.h
@@ -256,6 +256,8 @@ struct DashFrameInfo {
   const int* clear_bytes;  // Number of clear bytes in each subsample.
   const int* enc_bytes;    // Number of encrypted bytes in each subsample.
 
+  size_t width;
+  size_t height;
   // TODO(rdaum): Add timebase and timeline position.
 };
 


### PR DESCRIPTION
This change sets the initial window in the reference player to be a
reasonable size based on the aspect ratio of the detected codec.  All
video frames are then scaled into that window.  This way, resolution
changes (due to adaptive bitrate selection) are displayed properly.

Made media format a copy in the format holder (as in other places) rather
than attempting to keep pointers to memory owned elsewhere which can
cause issues.