### PR TITLE
Update build to work on more recent Debian/Ubuntu systems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/build)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 
+# Configure gtest/gmock
+include(cmake/GoogleTest.cmake)
+
 add_subdirectory(third_party/chromium/base)
 add_subdirectory(third_party/chromium/mp4)
 add_subdirectory(ndash)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ delivered by libndash using ffmpeg/SDL/Alsa.
 
 ## Libraries
 
+For Debian-type systems, the following packages should be installed:
+
 * libevent-dev
 * libmodpbase64-dev
 * libpthread-stubs0-dev
@@ -39,14 +41,52 @@ delivered by libndash using ffmpeg/SDL/Alsa.
 * libsdl2-dev
 * libsdl2-mixer-dev
 * libbz2-dev
+
+Copy and paste:
+
+apt-get install libevent-dev libmodpbase64-dev libpthread-stubs0-dev libxml2-dev \
+ libcurl4-gnutls-dev libsdl2-dev libsdl2-mixer-dev libbz2-dev
+
+If you are using a recent Debian/Ubuntu with an up to date ffmpeg:
+
+* libavcodec-dev
+* libavdevice-dev
+* libavfilter-dev
+* libavformat-dev
+* libavresample-dev
+* libavresample3
+* libavutil-dev
+* libswresample-dev
+* libswscale-dev
+* libgoogle-glog-dev
+* libgflags-dev
+
+Copy and paste:
+
+apt-get install libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavresample-dev \
+  libavresample3 libavutil-dev libswresample-dev libswscale-dev libgoogle-glog-dev libgflags-dev
+
+Otherwise you will need to install the following from source:
+
 * ffmpeg (https://github.com/FFmpeg/FFmpeg)
 * glog (https://github.com/google/glog)
-* googletest (https://github.com/google/googletest)
 * gflags (https://github.com/gflags/gflags)
 
   NOTE: If your ffmpeg was compiled with --enable-libx264, you will need to
         add x264 to CMakeLists.txt link rules for sdl_player.
 
+To build:
+
+From the top directory:
+
+cmake .
+make -jX  # where X is the number of cores on your machine or around there
+
+To run the unit tests:
+
+From the top directory:
+
+./build/ndash_unittests --test_data_path=`pwd`/ndash/src
 
 ## License
 

--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -21,7 +21,8 @@ add_compile_options(
         -fPIC
         -Wno-sign-compare
         -fno-exceptions
-        -Wno-deprecated-register
         -Wno-narrowing
         -Wno-psabi
+        -Wno-deprecated-declarations
+        -Wno-unused-function
         -Wno-unused-local-typedefs)

--- a/cmake/GoogleTest.cmake
+++ b/cmake/GoogleTest.cmake
@@ -1,0 +1,41 @@
+# We need thread support
+find_package(Threads REQUIRED)
+
+# Enable ExternalProject CMake module
+include(ExternalProject)
+
+# Download and install GoogleTest
+ExternalProject_Add(
+        gtest
+        URL https://github.com/google/googletest/archive/master.zip
+        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gtest
+        # Disable install step
+        INSTALL_COMMAND ""
+)
+
+# Get GTest source and binary directories from CMake project
+ExternalProject_Get_Property(gtest source_dir binary_dir)
+
+# Create a libgtest target to be used as a dependency by test programs
+add_library(libgtest IMPORTED STATIC GLOBAL)
+add_dependencies(libgtest gtest)
+
+# Set libgtest properties
+set_target_properties(libgtest PROPERTIES
+        "IMPORTED_LOCATION" "${binary_dir}/googlemock/gtest/libgtest.a"
+        "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+        )
+
+# Create a libgmock target to be used as a dependency by test programs
+add_library(libgmock IMPORTED STATIC GLOBAL)
+add_dependencies(libgmock gtest)
+
+# Set libgmock properties
+set_target_properties(libgmock PROPERTIES
+        "IMPORTED_LOCATION" "${binary_dir}/googlemock/libgmock_main.a"
+        "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+        )
+
+# I couldn't make it work with INTERFACE_INCLUDE_DIRECTORIES
+include_directories("${source_dir}/googletest/include"
+        "${source_dir}/googlemock/include")

--- a/examples/sdl_player/CMakeLists.txt
+++ b/examples/sdl_player/CMakeLists.txt
@@ -21,8 +21,6 @@ include_directories(src)
 # Include paths relative to src directory.
 include_directories(../../ndash/src)
 
-# Find some packages.
-find_package(GTest REQUIRED)
 find_package(gflags REQUIRED)
 
 include(FindPkgConfig)
@@ -93,7 +91,8 @@ function(define_test name sources)
     add_executable(${name} ${sources})
     target_link_libraries(${name}
             native-player-lib
-            ${GTEST_BOTH_LIBRARIES}
+            libgtest
+            libgmock
             ${GLOG_LIBRARY}
             pthread)
     add_test(${name} ${name})

--- a/ndash/CMakeLists.txt
+++ b/ndash/CMakeLists.txt
@@ -32,17 +32,8 @@ pkg_search_module(STRINGENCODERS stringencoders REQUIRED)
 include_directories(${XML2_INCLUDE_DIRS})
 include_directories(${STRINGENCODERS_INCLUDE_DIRS})
 
-# Look for gmock/gtest
-find_package(GTest REQUIRED)
-include_directories(${GTEST_INCLUDE_DIRS})
-
 find_package(gflags REQUIRED)
 include_directories(${GFLAGS_INCLUDE_DIRS})
-
-find_library(GMOCK_LIBRARY NAMES gmock)
-if(NOT GMOCK_LIBRARY)
-    message(FATAL_ERROR "GMock library not found")
-endif(NOT GMOCK_LIBRARY)
 
 find_library(GLOG_LIBRARY NAMES glog)
 if(NOT GLOG_LIBRARY)
@@ -409,8 +400,8 @@ target_link_libraries(ndash_unittests
         ${LIBEVENT_LIBRARIES}
         ${LIBCURL_LIBRARIES}
         ${STRINGENCODERS_LIBRARIES}
-        ${GTEST_LIBRARIES}
-        ${GMOCK_LIBRARY}
+        libgtest
+        libgmock
         ${GFLAGS_LIBRARIES}
         ${GLOG_LIBRARY}
 )

--- a/third_party/chromium/base/CMakeLists.txt
+++ b/third_party/chromium/base/CMakeLists.txt
@@ -18,9 +18,6 @@ cmake_minimum_required(VERSION 2.8)
 # Include paths relative to src directory.
 include_directories(src)
 
-find_package(GTest REQUIRED)
-include_directories(${GTEST_INCLUDE_DIRS})
-
 # Turn on C++11 in a way portable across CMake versions.
 include(../../../cmake/Cxx11.cmake)
 use_cxx11()
@@ -259,7 +256,4 @@ list(APPEND BASE_TEST_SOURCES
         src/base/test/test_file_util_linux.cc
         src/base/test/simple_test_clock.h)
 add_library(chromium-base-test ${BASE_TEST_SOURCES})
-add_dependencies(chromium-base-test chromium-base)
-
-
-
+add_dependencies(chromium-base-test chromium-base libgtest libgmock)


### PR DESCRIPTION
  * Fix compile flags to make chrome base build for more recent compilers.
  * Use googletest as our own compiled external project rather than rely on system dependency.
  * Update README to reflect that Debian packages can be used for ffmpeg, gflags, and glog